### PR TITLE
fix: correct services teaser data mapping

### DIFF
--- a/app/Data/LayoutModules/ServicesTeaserData.php
+++ b/app/Data/LayoutModules/ServicesTeaserData.php
@@ -69,7 +69,7 @@ final class ServicesTeaserData extends Data
 
         // Map each entry to a ServicesTeaserItemData instance
         $entries = $raw_entries->map(
-            fn ($entry) => ServicesTeaserItemData::from($entry)
+            fn ($entry) => ServicesTeaserItemData::fromEntry($entry)
         )->all();
 
         return new self($headline, $intro_text, $overline, $entries);

--- a/app/Data/LayoutModules/ServicesTeaserItemData.php
+++ b/app/Data/LayoutModules/ServicesTeaserItemData.php
@@ -40,7 +40,7 @@ final class ServicesTeaserItemData extends Data
     public static function fromEntry(Entry $entry): self
     {
         // Extract and prepare values from the Entry
-        $icon = SvgIconData::from($entry->augmentedValue('icon'));
+        $icon = SvgIconData::fromIconValue($entry->augmentedValue('icon'));
 
         // Access the `teaser` property directly, assuming it has the specified structure
         $headline = $entry->teaser->title;


### PR DESCRIPTION
## Summary
- ensure ServicesTeaserData uses custom factory for items
- correctly parse icons via fromIconValue

## Testing
- `composer test` *(fails: Could not open input file: ./vendor/bin/pest)*

------
https://chatgpt.com/codex/tasks/task_b_688bd69c4bc88329b3e2c4f888dc014d