### PR TITLE
chore(ci): slim down deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,16 +1,12 @@
 name: Deploy
 
 on:
-  push:
-    branches:
-      - main
   release:
     types:
       - published
 
 jobs:
   forge_deploy_production:
-    if: github.event_name == 'release' && github.event.action == 'published'
     name: Laravel Forge Deploy to Production
     runs-on: ubuntu-latest
     environment:
@@ -20,12 +16,6 @@ jobs:
       group: production
       cancel-in-progress: true
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v6
-      - name: Setup SSH
-        uses: webfactory/ssh-agent@v0.10.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:


### PR DESCRIPTION
## Kontext

Der Deploy-Workflow schlägt seit dem Forge-Organizations-Rollout fehl ([Run 30620955051](https://github.com/21stdigital/21st.digital/actions/runs/30620955051), Release v2.2.7):

```
 Current organization changed successfully to 21st digital
 ⠶ Retrieving servers
   Forbidden.
```

Die eigentliche Ursache liegt nicht im Workflow, sondern beim API-Token: `403 Forbidden` bedeutet, dass der Token authentifiziert ist, aber `GET /orgs/21st-digital/servers` nicht lesen darf. Das wird separat durch ein neues Token mit den Scopes `organization:view`, `server:view` und `site:manage-deploys` behoben — dieser PR ändert daran nichts.

Was dieser PR macht: den Workflow von allem befreien, was er nicht braucht.

## Änderungen

- **`Checkout Code` entfernt** — `forge deploy` läuft rein über die Forge-API, der Job greift an keiner Stelle auf das Repository zu.
- **`Setup SSH` entfernt** — kein SSH nötig. Nur `forge ssh`/`tinker`/Shell-Kommandos bräuchten den Agent. Nebeneffekt: der Production-SSH-Key wird nicht mehr in den Runner geladen.
- **`push: main`-Trigger samt `if`-Guard entfernt** — der Guard hat ausschließlich Release-Events durchgelassen, wodurch jeder Push auf `main` einen sofort übersprungenen Run erzeugt hat (z. B. Run `30620920040`, 1s, *skipped*). `release: published` deckt den Trigger allein ab.

Damit bleiben drei Steps: PHP aufsetzen, Forge CLI installieren, deployen.

## Hinweise

- `secrets.SSH_PRIVATE_KEY` wird nach diesem PR nirgends mehr in `.github/` verwendet und kann aus den Repo-Secrets entfernt werden, sofern es nicht anderweitig gebraucht wird.
- Deploy-Runs sind künftig nur noch über einen Release auslösbar. Falls manuelles Deployen gewünscht ist, wäre `workflow_dispatch` die passende Ergänzung.
- Der Deploy-Workflow ist kein required status check im Ruleset des Default-Branches — der entfallende `push`-Trigger blockiert also keine Merges.

## Testing

Nicht in CI verifizierbar, ohne einen Release zu publishen. Der nächste Deploy-Run wird weiterhin an `Forbidden` scheitern, solange das neue Forge-Token nicht in `FORGE_API_KEY` liegt — das ist unabhängig von diesem PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjEjYtRVhqDQXffKc9aX2F